### PR TITLE
Update README.md to read next entry if directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ yauzl.open("path/to/file.zip", {lazyEntries: true}, function(err, zipfile) {
       // Directory file names end with '/'.
       // Note that entires for directories themselves are optional.
       // An entry's fileName implicitly requires its parent directories to exist.
+      zipfile.readEntry();
     } else {
       // file entry
       zipfile.openReadStream(entry, function(err, readStream) {


### PR DESCRIPTION
In the example in the README, if the entry is a directory then the next entry is never read and the entire Zip file is not processed.  This updates the example to read the next entry if it is directory.